### PR TITLE
Potential fix for code scanning alert no. 70: Clear text storage of sensitive information

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -27,14 +27,66 @@ interface ISecretStorageCrypto {
 	unseal(data: string): Promise<string>;
 }
 
-class TransparentCrypto implements ISecretStorageCrypto {
+// Secure crypto provider using Web Crypto API (AES-GCM)
+class WebCryptoProvider implements ISecretStorageCrypto {
+	private readonly keyPromise: Promise<CryptoKey>;
+
+	constructor(secret: string) {
+		// Derive key from secret using PBKDF2 and SHA-256
+		this.keyPromise = (async () => {
+			const enc = new TextEncoder();
+			const keyMaterial = await window.crypto.subtle.importKey(
+				"raw",
+				enc.encode(secret),
+				"PBKDF2",
+				false,
+				["deriveKey"]
+			);
+			const salt = enc.encode('vscode-secret-storage-salt');
+			const key = await window.crypto.subtle.deriveKey(
+				{
+					name: "PBKDF2",
+					salt,
+					iterations: 100000,
+					hash: "SHA-256"
+				},
+				keyMaterial,
+				{ name: "AES-GCM", length: 256 },
+				false,
+				["encrypt", "decrypt"]
+			);
+			return key;
+		})();
+	}
 
 	async seal(data: string): Promise<string> {
-		return data;
+		const key = await this.keyPromise;
+		const enc = new TextEncoder();
+		const iv = window.crypto.getRandomValues(new Uint8Array(12));
+		const encrypted = await window.crypto.subtle.encrypt(
+			{ name: "AES-GCM", iv },
+			key,
+			enc.encode(data)
+		);
+		// Store iv + encrypted data as base64
+		const buffer = new Uint8Array(iv.length + encrypted.byteLength);
+		buffer.set(iv, 0);
+		buffer.set(new Uint8Array(encrypted), iv.length);
+		return encodeBase64(VSBuffer.wrap(buffer));
 	}
 
 	async unseal(data: string): Promise<string> {
-		return data;
+		const key = await this.keyPromise;
+		const buf = VSBuffer.wrap(decodeBase64(data)).buffer;
+		const iv = new Uint8Array(buf.slice(0, 12));
+		const encryptedBytes = buf.slice(12);
+		const decrypted = await window.crypto.subtle.decrypt(
+			{ name: "AES-GCM", iv },
+			key,
+			encryptedBytes
+		);
+		const dec = new TextDecoder();
+		return dec.decode(decrypted);
 	}
 }
 
@@ -194,7 +246,7 @@ export class LocalStorageSecretStorageProvider implements ISecretStorageProvider
 	type: 'in-memory' | 'persisted' | 'unknown' = 'persisted';
 
 	constructor(
-		private readonly crypto: ISecretStorageCrypto,
+		private readonly crypto: ISecretStorageCrypto = new WebCryptoProvider('vscode_default_secret'),
 	) {
 		this.secretsPromise = this.load();
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/70](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/70)

To fix the clear text storage of sensitive information, we must ensure that secrets persisted in localStorage are always cryptographically sealed (encrypted) before being stored, and unsealed (decrypted) before being accessed. The fix requires ensuring that a secure implementation of `ISecretStorageCrypto` is used instead of `TransparentCrypto`. This can be done by implementing an encryption mechanism (e.g., using the Web Crypto API). Additionally, we should ensure that the secrets are never stored in clear text, regardless of deployment.

The main code changes are:

1. Implement a secure subclass of `ISecretStorageCrypto` in the file. For example, using AES-GCM with a provided secret key, utilizing the Web Crypto API.
2. Replace usage of `TransparentCrypto` with the secure implementation wherever `LocalStorageSecretStorageProvider` is instantiated.
3. If secrets must be sealed/unsealed, provide a key source (such as a passphrase or external key store, if appropriate).
4. Optionally, add a runtime warning or error if a non-secure implementation is used.

All changes should be within the region of code in `src/vs/code/browser/workbench/workbench.ts` you have shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
