### PR TITLE
Potential fix for code scanning alert no. 64: Inefficient regular expression

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -71,7 +71,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 				 * Certain ranges that are matched here do not contain real graphics rendition sequences. For
 				 * the sake of having a simpler expression, they have been included anyway.
 				 */
-				if (ansiSequence.match(/^(?:[34][0-8]|9[0-7]|10[0-7]|[0-9]|2[1-5,7-9]|[34]9|5[8,9]|1[0-9])(?:;[349][0-7]|10[0-7]|[013]|[245]|[34]9)?(?:;[012]?[0-9]?[0-9])*;?m$/)) {
+				if (ansiSequence.match(/^(?:[34][0-8]|9[0-7]|10[0-7]|[0-9]|2[1-5,7-9]|[34]9|5[8,9]|1[0-9])(?:;[349][0-7]|10[0-7]|[013]|[245]|[34]9)?(?:;[0-9]{1,3})*;?m$/)) {
 
 					const styleCodes: number[] = ansiSequence.slice(0, -1) // Remove final 'm' character.
 						.split(';')										   // Separate style codes.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/64](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/64)

The fix is to remove the ambiguity inside the repeated group in the regular expression on line 74.  
Specifically, the issue lies with `(?:;[012]?[0-9]?[0-9])*`, which allows matching a semicolon followed by 0-3 digits, where each digit is optionally matched, leading to ambiguity about how digits are grouped within repetitions.  
To resolve the issue, refactor this sub-pattern so that at each repetition, the semicolon is always followed by 1 to 3 digits (not any number optional), thus eliminating ambiguity: use `;[0-9]{1,3}` instead of `;[012]?[0-9]?[0-9]`.  
This change keeps the same functional logic: it matches a semicolon and 1-3 digits, but no longer allows a digit to be split ambiguously between adjacent groups or optional digits.  
So, replace `(?:;[012]?[0-9]?[0-9])*` with `(?:;[0-9]{1,3})*` in the regex on line 74 in file `src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts`.  
No imports or additional logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
