### PR TITLE
Potential fix for code scanning alert no. 63: Inefficient regular expression

### DIFF
--- a/extensions/notebook-renderers/src/ansi.ts
+++ b/extensions/notebook-renderers/src/ansi.ts
@@ -59,7 +59,7 @@ export function handleANSIOutput(text: string, linkOptions: LinkOptions): HTMLSp
 				 * Certain ranges that are matched here do not contain real graphics rendition sequences. For
 				 * the sake of having a simpler expression, they have been included anyway.
 				 */
-				if (ansiSequence.match(/^(?:[34][0-8]|9[0-7]|10[0-7]|[0-9]|2[1-5,7-9]|[34]9|5[8,9]|1[0-9])(?:;[349][0-7]|10[0-7]|[013]|[245]|[34]9)?(?:;[012]?[0-9]?[0-9])*;?m$/)) {
+				if (ansiSequence.match(/^(?:[34][0-8]|9[0-7]|10[0-7]|[0-9]|2[1-5,7-9]|[34]9|5[8,9]|1[0-9])(?:;[349][0-7]|10[0-7]|[013]|[245]|[34]9)?(?:;[0-9]{1,3})*;?m$/)) {
 
 					const styleCodes: number[] = ansiSequence.slice(0, -1) // Remove final 'm' character.
 						.split(';')										   // Separate style codes.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/63](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/63)

To fix the problem, the ambiguous regular expression segment must be rewritten so that within the repeated pattern, each character in the target substring is matched unambiguously by a single subexpression. Specifically, the problematic part is `(?:;[012]?[0-9]?[0-9])*`, which is meant to match numeric arguments separated by semicolons, as per ANSI escape sequence formats. Instead of using optional matches (`[012]?`, `[0-9]?`, `[0-9]?`) that can overlap, a clear alternative is to match decimal numbers between 0 and 255 explicitly, which means allowing one to three digits. The safest efficient replacement is to use a pattern like `(?:;([0-9]{1,3}))`, which matches a semicolon followed by 1 to 3 digits. This avoids ambiguity and ensures that each digit is consumed by a single branch.

In the regular expression on line 62, replace the ambiguous construct with the improved version. No new imports or methods are needed; only the regular expression literal needs to be updated in place.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
