### PR TITLE
Potential fix for code scanning alert no. 61: Inefficient regular expression

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/snippets.ts
@@ -7,7 +7,7 @@
  * Resolves variables in a VS Code snippet style string
  */
 export function resolveSnippet(snippetString: string, vars: ReadonlyMap<string, string>): string {
-	return snippetString.replaceAll(/(?<escape>\\\$)|(?<!\\)\$\{(?<name>\w+)(?:\/(?<pattern>(?:\\\/|[^\}])+?)\/(?<replacement>(?:\\\/|[^\}])+?)\/)?\}/g, (match, _escape, name, pattern, replacement, _offset, _str, groups) => {
+	return snippetString.replaceAll(/(?<escape>\\\$)|(?<!\\)\$\{(?<name>\w+)(?:\/(?<pattern>(?:\\\/|[^\/}])+?)\/(?<replacement>(?:\\\/|[^\/}])+?)\/)?\}/g, (match, _escape, name, pattern, replacement, _offset, _str, groups) => {
 		if (groups?.['escape']) {
 			return '$';
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/61](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/61)

The issue arises from an ambiguous alternation within the repeated grouping: `(?:\\\/|[^\}])+?`. The problem is that both alternatives may match an initial `'\'` (if the next character is `'/'`), so the engine can backtrack in exponentially many ways when scanning a string with many `'\\/'` substrings. To fix this, the ambiguous alternatives should be rewritten so that they do not overlap—most simply, by matching an escaped slash specifically, or any *other* character except `'/'` and `}`. The best fix thus is to change `[^\}]` to match any character except '/' *and* '}' (i.e., using `[^\/}]`). The subpattern then becomes `(?:\\\/|[^\/}])+?`, which matches either an escaped slash or any non-slash, non-}` character, unambiguously.

Change only the regular expression in line 10 within `snippets.ts`, replacing `[^\}]` with `[^\/}]`.

No additional imports or helper functions are needed—just this regex edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
