### PR TITLE
Potential fix for code scanning alert no. 49: Client-side cross-site scripting

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -10,6 +10,7 @@ import { getEditorLineNumberForPageOffset, scrollToRevealSourceLine, getLineElem
 import { SettingsManager, getData, getRawData } from './settings';
 import throttle = require('lodash.throttle');
 import morphdom from 'morphdom';
+import DOMPurify from 'dompurify';
 import type { ToWebviewMessage } from '../types/previewMessaging';
 import { isOfScheme, Schemes } from '../src/util/schemes';
 
@@ -206,7 +207,8 @@ window.addEventListener('message', async event => {
 			const root = document.querySelector('.markdown-body')!;
 
 			const parser = new DOMParser();
-			const newContent = parser.parseFromString(data.content, 'text/html'); // CodeQL [SM03712] This renderers content from the workspace into the Markdown preview. Webviews (and the markdown preview) have many other security measures in place to make this safe
+			const sanitizedContent = DOMPurify.sanitize(data.content);
+			const newContent = parser.parseFromString(sanitizedContent, 'text/html'); // CodeQL [SM03712] This renderers content from the workspace into the Markdown preview. Webviews (and the markdown preview) have many other security measures in place to make this safe
 
 			// Strip out meta http-equiv tags
 			for (const metaElement of Array.from(newContent.querySelectorAll('meta'))) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/49](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/49)

To resolve the DOM-based XSS risk from untrusted HTML, sanitize the HTML content (`data.content`) before using it in `DOMParser.parseFromString` (and/or before inserting it into the DOM). The best practice is to use a well-known, actively maintained HTML sanitization library which will strip scripts, event handlers, forms, iframes, and other dangerous elements/attributes. For TypeScript projects, the `dompurify` library is a widely accepted solution for client-side HTML sanitization.

**Concrete fix steps:**
- Import and configure `dompurify` in `extensions/markdown-language-features/preview-src/index.ts`.
- Sanitize `data.content` using `DOMPurify.sanitize(data.content)` before passing it to `DOMParser.parseFromString`.
- Replace the vulnerable line:  
  ```ts
  const newContent = parser.parseFromString(data.content, 'text/html');
  ```  
  with  
  ```ts
  const sanitized = DOMPurify.sanitize(data.content);
  const newContent = parser.parseFromString(sanitized, 'text/html');
  ```
- Add the import for `dompurify`.
- No other functional changes or modifications needed as the rest of the HTML parsing logic remains safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
