### PR TITLE
Potential fix for code scanning alert no. 19: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/src/vs/platform/languagePacks/node/languagePacks.ts
+++ b/src/vs/platform/languagePacks/node/languagePacks.ts
@@ -170,11 +170,11 @@ class LanguagePacksCache extends Disposable {
 
 	private updateHash(languagePack: ILanguagePack): void {
 		if (languagePack) {
-			const md5 = createHash('md5'); // CodeQL [SM04514] Used to create an hash for language pack extension version, which is not a security issue
+			const sha256 = createHash('sha256'); // Secure hash algorithm for language pack extension version
 			for (const extension of languagePack.extensions) {
-				md5.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // CodeQL [SM01510] The extension UUID is not sensitive info and is not manually created by a user
+				sha256.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // Using secure hash for identifier
 			}
-			languagePack.hash = md5.digest('hex');
+			languagePack.hash = sha256.digest('hex');
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/19](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/19)

To resolve the issue, replace the use of MD5 with a secure hash function (e.g., SHA-256) without changing the way the hash is created or used elsewhere. Specifically, change the invocation `createHash('md5')` (line 173) to `createHash('sha256')` in the `updateHash` method. This ensures the hash is strong, collision-resistant, and future-proof. No other code needs to be changed as the output format ('hex') and logic do not depend on the hash function.

You only need to change the algorithm name in the existing call. No imports or other adjustments are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
