### PR TITLE
Potential fix for code scanning alert no. 41: Useless regular-expression character escape

### DIFF
--- a/extensions/json/build/update-grammars.js
+++ b/extensions/json/build/update-grammars.js
@@ -9,7 +9,7 @@ var updateGrammar = require('vscode-grammar-updater');
 function adaptJSON(grammar, name, replacementScope, replaceeScope = 'json') {
 	grammar.name = name;
 	grammar.scopeName = `source${replacementScope}`;
-	const regex = new RegExp(`\.${replaceeScope}`, 'g');
+	const regex = new RegExp(`\\.${replaceeScope}`, 'g');
 	var fixScopeNames = function (rule) {
 		if (typeof rule.name === 'string') {
 			rule.name = rule.name.replace(regex, replacementScope);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/41](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/41)

The problem is that in the argument to `RegExp`, the string `\.${replaceeScope}` only escapes the dot if written as `'\\.' + replaceeScope` or `` `\\.${replaceeScope}` ``, because in a JavaScript string, `\.` is just `.`, and in a regex pattern, `.` is a wildcard, not a literal dot. So to produce a regex that matches a literal dot, we need a double backslash in the JavaScript string, so that the regex engine sees a single backslash and interprets `\.` as a literal dot.

To fix this, change line 12 to:
```js
const regex = new RegExp(`\\.${replaceeScope}`, 'g');
```
This ensures the resulting regex is matching a literal dot followed by the same replacement scope (like `.json`), rather than any character plus the replacement scope.

No other parts of the code need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
