### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -1008,7 +1008,7 @@ const html = edit('^ {0,3}(?:' // optional indentation
     .replace('tag', _tag)
     .replace('attribute', / +[a-zA-Z:_][\w.:-]*(?: *= *"[^"\n]*"| *= *'[^'\n]*'| *= *[^\s"'=<>`]+)?/)
     .getRegex();
-const paragraph = edit(_paragraph)
+const paragraph = edit(_paragraph, 'i') // <-- add 'i' flag for case-insensitivity
     .replace('hr', hr)
     .replace('heading', ' {0,3}#{1,6}(?:\\s|$)')
     .replace('|lheading', '') // setext headings don't interrupt commonmark paragraphs


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/1](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/1)

- **General fix:** Ensure that the regular expression used for matching HTML tags is **case-insensitive** so that it matches tag names such as `<SCRIPT>`, `<ScRiPt>`, and so on, in addition to lowercase forms. This can be done by adding the `i` (case-insensitive) flag to the regex where relevant.
- In the code provided, the problematic regex is in a call to `edit` on line 1011 (`const paragraph = edit(_paragraph)...`), and within that chain, the string `html` is defined as: `</?(?:tag)(?: +|\n|/?>)|<(?:script|pre|style|textarea|!--)`.
- The fix is straightforward: ensure that the regex created for `paragraph` is case-insensitive. This is typically achieved by making sure the `edit()` function (presumably a regex builder) allows specifying regex flags, and specifically passes/include an `i` flag when generating the regex for `paragraph`.
- Specifically, in the block of code where `edit(_paragraph)` is used, ensure the regex flags include `i` (not just `m` or others). If the `edit` function call chain allows passing flags, add or ensure `i` is provided. If other code uses `edit()` with explicit flags, make this chain consistent.
- Only lines related to the construction of the `paragraph` regex (and possibly other HTML-related regexes if they also should be case-insensitive) need to be changed. That would likely mean passing an `i` option to `edit(_paragraph, 'i')` or equivalent based on the interface.
- No additional dependencies are needed; this fix only adjusts the regex flags.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
