### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -70,6 +70,7 @@ export class MarkdownString implements IMarkdownString {
 
 	appendText(value: string, newlineStyle: MarkdownStringTextNewlineStyle = MarkdownStringTextNewlineStyle.Paragraph): MarkdownString {
 		this.value += escapeMarkdownSyntaxTokens(this.supportThemeIcons ? escapeIcons(value) : value) // CodeQL [SM02383] The Markdown is fully sanitized after being rendered.
+			.replace(/\\/g, '\\\\') // Escape backslash characters
 			.replace(/([ \t]+)/g, (_match, g1) => '&nbsp;'.repeat(g1.length)) // CodeQL [SM02383] The Markdown is fully sanitized after being rendered.
 			.replace(/\>/gm, '\\>') // CodeQL [SM02383] The Markdown is fully sanitized after being rendered.
 			.replace(/\n/g, newlineStyle === MarkdownStringTextNewlineStyle.Break ? '\\\n' : '\n\n'); // CodeQL [SM02383] The Markdown is fully sanitized after being rendered.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/9](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/9)

To fix the incomplete string escaping, we should ensure that the input text provided to `appendText()` has all Markdown syntax token characters escaped, including the backslash. The most targeted way is to enhance the escaping function in use (`escapeMarkdownSyntaxTokens` or at the call site) so that it replaces every backslash (`\`) with double backslashes (`\\`) before further processing. This will prevent Markdown from treating backslashes as escape indicators for subsequent symbols.

The best fix, without changing broader functionality, is to add a `.replace(/\\/g, '\\\\')` call after (or preferably within) the escaping in line 72. If the escaping function is already supposed to escape all necessary meta-characters, but doesn't escape backslash, we fix it directly in the call chain at `appendText`.

Edit only the code in `src/vs/base/common/htmlContent.ts` at line 72 in the `appendText()` method to ensure all backslash characters are escaped before further processing.

No additional imports or dependencies are needed to use `String.replace` with a RegExp.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
