### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete string escaping or encoding

### DIFF
--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -240,7 +240,10 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 					spawnOptions.shell = true;
 					spawnCommand = `"${command}"`;
 					spawnArgs = args.map(a => {
-						a = a.replace(/"/g, '\\"'); // Escape existing double quotes with \
+						// Escape backslashes first
+						a = a.replace(/\\/g, '\\\\');
+						// Then escape double quotes
+						a = a.replace(/"/g, '\\"');
 						// Wrap in double quotes
 						return `"${a}"`;
 					});


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/13](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/13)

To correctly escape command arguments for Windows shell invocation, both backslashes and double quotes must be escaped, as a backslash before a double quote in a quoted string can escape the quote, altering argument boundaries. The best-practice is to first replace all backslashes (`\`) with double backslashes (`\\`), and *then* escape all double quotes (`"`) by replacing them with `\\"` (within TypeScript/JavaScript, that's `\\\"`). This prevents situations where an original backslash would "escape" a double quote and break out of quoting. The correct order of operations is to escape backslashes first, then double quotes. The fix is strictly localized to the `.map` call on `args` at line 243, so making changes to the escape logic within this anonymous function is sufficient. No additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
