### PR TITLE
Potential fix for code scanning alert no. 42: Useless regular-expression character escape

### DIFF
--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -69,7 +69,7 @@ export class ReplEditorInput extends NotebookEditorInput implements ICompositeNo
 		}
 
 		if (resource.scheme === 'untitled') {
-			const match = new RegExp('Untitled-(\\d+)\.').exec(resource.path);
+			const match = new RegExp('Untitled-(\\d+)\\.').exec(resource.path);
 			if (match?.length === 2) {
 				return `REPL - ${match[1]}`;
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/42](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/42)

To fix the problem, update the regular expression string so that the dot is correctly escaped for both the string literal and the regular expression. In a regex string used with the `RegExp` constructor, a literal `.` must be double-escaped (`\\.`): once to put a literal backslash in the string, and once for the regex engine to interpret that as an escaped dot. Therefore, replace `'Untitled-(\\d+)\.'` with `'Untitled-(\\d+)\\.'`.

Specifically:  
- Edit the file `src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts`.
- Change line 72 from:
  ```ts
  const match = new RegExp('Untitled-(\\d+)\.').exec(resource.path);
  ```
  to:
  ```ts
  const match = new RegExp('Untitled-(\\d+)\\.').exec(resource.path);
  ```
- No new dependencies or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
