### PR TITLE
Potential fix for code scanning alert no. 48: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/simple-browser/preview-src/index.ts
+++ b/extensions/simple-browser/preview-src/index.ts
@@ -90,18 +90,27 @@ onceDocumentLoaded(() => {
 	toggleFocusLockIndicatorEnabled(settings.focusLockIndicatorEnabled);
 
 	function navigateTo(rawUrl: string): void {
+		let safeUrl: string | null = null;
 		try {
 			const url = new URL(rawUrl);
-
-			// Try to bust the cache for the iframe
-			// There does not appear to be any way to reliably do this except modifying the url
-			url.searchParams.append('vscodeBrowserReqId', Date.now().toString());
-
-			iframe.src = url.toString();
+			if (url.protocol === 'http:' || url.protocol === 'https:') {
+				// Try to bust the cache for the iframe
+				url.searchParams.append('vscodeBrowserReqId', Date.now().toString());
+				safeUrl = url.toString();
+			}
 		} catch {
-			iframe.src = rawUrl;
+			// Fallback if URL parsing fails
+			// Try to match http/https only
+			if (/^(https?:\/\/)/i.test(rawUrl)) {
+				safeUrl = rawUrl;
+			}
 		}
-
+		if (safeUrl) {
+			iframe.src = safeUrl;
+		} else {
+			// Optionally, display an error or set to about:blank
+			iframe.src = 'about:blank';
+		}
 		vscode.setState({ url: rawUrl });
 	}
 });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/48](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/48)

To fix the issue, we need to make sure that the value assigned to `iframe.src` is a safe, valid URL. In particular, we should restrict navigation to prevent assignment of untrusted schemes like `javascript:`, `data:`, or other potentially dangerous protocols. The best fix is to check that the provided URL uses an allowed protocol (e.g., `http:`, `https:`), and only assign to `iframe.src` if this is the case; otherwise, display an error or fallback to a safe value. 

The code to change is in the `navigateTo` function (lines 92–106), specifically in the fallback when URL parsing fails, on line 102. We should ensure that even when a URL parse fails, or if the string contains a suspicious prefix, we do not assign it to `iframe.src`.  
Required methods/imports: none external; we can implement this with basic string and URL logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
