### PR TITLE
Potential fix for code scanning alert no. 20: Regular expression injection

### DIFF
--- a/src/vs/base/common/marshalling.ts
+++ b/src/vs/base/common/marshalling.ts
@@ -33,6 +33,10 @@ function replacer(key: string, value: any): any {
 	return value;
 }
 
+// Utility function to escape RegExp special characters
+function escapeRegExp(string: string): string {
+	return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
 
 type Deserialize<T> = T extends UriComponents ? URI
 	: T extends VSBuffer ? VSBuffer
@@ -51,7 +55,7 @@ export function revive<T = any>(obj: any, depth = 0): Revived<T> {
 
 		switch ((<MarshalledObject>obj).$mid) {
 			case MarshalledId.Uri: return <any>URI.revive(obj);
-			case MarshalledId.Regexp: return <any>new RegExp(obj.source, obj.flags);
+			case MarshalledId.Regexp: return <any>new RegExp(escapeRegExp(obj.source), obj.flags);
 			case MarshalledId.Date: return <any>new Date(obj.source);
 		}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/20](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/20)

To fix the issue, we should escape any RegExp meta-characters in the `source` string before constructing the RegExp on hydration in the revive() function. This ensures that even if the serialized payload includes malicious content, it will be treated as a literal string pattern, not arbitrary RegExp code.  
The recommended way is to use a well-known library such as lodash's `_.escapeRegExp` to sanitize `obj.source` before passing it to the RegExp constructor. If lodash is not present, we can define a minimal escape function.  

**Change:**  
- In `src/vs/base/common/marshalling.ts`, in the `revive` function, case for `MarshalledId.Regexp`:  
  - Escape `obj.source` prior to constructing the RegExp object.
- Add import for lodash or, as an alternative, a local `escapeRegExp` utility if lodash is not used in this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
