### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
@@ -210,7 +210,8 @@ function convertLinkTags(
 }
 
 function escapeMarkdownSyntaxTokensForCode(text: string): string {
-	return text.replace(/`/g, '\\$&'); // CodeQL [SM02383] This is only meant to escape backticks. The Markdown is fully sanitized after being rendered.
+	// First escape backslashes, then backticks
+	return text.replace(/\\/g, '\\\\').replace(/`/g, '\\$&'); // CodeQL [SM02383] This now escapes backticks and backslashes.
 }
 
 export function tagsToMarkdown(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/8](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/8)

To fix the problem, the code should escape both backticks and backslashes in the input string. The fix should update the `escapeMarkdownSyntaxTokensForCode` function to replace every backslash (`\`) with a double backslash (`\\`), **before** escaping backticks. This prevents accidental "un-escaping" of characters. Only the function in question (lines 212–214) needs to be changed; it does not require any new imports or external libraries since JavaScript's standard `.replace` with a regex suffices. The fix is to perform `.replace(/\\/g, '\\\\')` first, then `.replace(/`/g, '\\$&')` as before.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
