### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through a stack trace

### DIFF
--- a/src/vs/workbench/api/node/extHostCLIServer.ts
+++ b/src/vs/workbench/api/node/extHostCLIServer.ts
@@ -112,8 +112,7 @@ export class CLIServerBase {
 				}
 				sendResponse(200, returnObj);
 			} catch (e) {
-				const message = e instanceof Error ? e.message : JSON.stringify(e);
-				sendResponse(500, message);
+				sendResponse(500, "An internal server error occurred.");
 				this.logService.error('Error while processing pipe request', e);
 			}
 		});


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/18](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/18)

To fix the problem, we must ensure that the server does *not* send error messages (even just their `.message` property) directly back to clients. Instead, send a generic error message (e.g., `"An internal server error occurred."`) when catching exceptions, while *logging* the original error details server-side for debugging.

Specifically, in `src/vs/workbench/api/node/extHostCLIServer.ts`:
- In the error handler at line 114–117, change the block to send a generic string (e.g. "An internal server error occurred" or "Internal server error") as the value for `returnObj` instead of propagating potentially sensitive messages from exceptions via `e.message` or `JSON.stringify(e)`.
- Do *not* alter the logging line — errors and their full messages should still be logged for developer diagnosis.

No new methods or imports are needed; only the error-handling code inside the `onRequest` function needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
