### PR TITLE
Potential fix for code scanning alert no. 78: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/monaco-editor.yml
+++ b/.github/workflows/monaco-editor.yml
@@ -1,4 +1,6 @@
 name: Monaco Editor checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/78](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/78)

The best fix is to add a `permissions` block specifying the least permissions required for the workflow/job. Since this workflow only appears to read repository contents (code, dependencies, etc.) and does not push changes or interact with issues, pull-requests, etc., the `contents: read` permission is sufficient. You should add a `permissions: contents: read` block either at the workflow root (applies to all jobs, preferred if all jobs need only read) or at the job level (under `main:` in this case). Since there is only one job shown, either scope suffices, but adding at the top makes the file clearer and safest for future jobs.  
**Change:** Insert the following block after the workflow `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
