### PR TITLE
Potential fix for code scanning alert no. 15: Incomplete string escaping or encoding

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
@@ -275,7 +275,7 @@ export class TerminalProfileQuickpick {
 			}
 			const argsString = profile.args.map(e => {
 				if (e.includes(' ')) {
-					return `"${e.replace(/"/g, '\\"')}"`; // CodeQL [SM02383] js/incomplete-sanitization This is only used as a label on the UI so this isn't a problem
+					return `"${e.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`; // First escape backslashes, then quotes for correct display
 				}
 				return e;
 			}).join(' ');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/15](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/15)

The correct way to escape both double quotes and backslashes is to first escape every backslash (`\` → `\\`) and then every double quote (`"` → `\"`). This ensures that a sequence like `C:\Program "File"` becomes `C:\\Program \"File\"`, which both preserves the string's content and displays as intended in the UI. Change line 278 within the `_createProfileQuickPickItem` method so that it performs these two replacement steps on each argument. Only this block needs updating, no imports or external libraries are required. All context and variable usages remain unchanged, and the method's outcome (UI labels) is preserved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
