### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
@@ -103,7 +103,7 @@ class JsDocCompletionProvider implements vscode.CompletionItemProvider {
 export function templateToSnippet(template: string): vscode.SnippetString {
 	// TODO: use append placeholder
 	let snippetIndex = 1;
-	template = template.replace(/\$/g, '\\$'); // CodeQL [SM02383] This is only used for text which is put into the editor. It is not for rendered html
+	template = template.replace(/\\/g, '\\\\').replace(/\$/g, '\\$'); // Escape backslash and dollar for VSCode snippets
 	template = template.replace(/^[ \t]*(?=(\/|[ ]\*))/gm, '');
 	template = template.replace(/^(\/\*\*\s*\*[ ]*)$/m, (x) => x + `\$0`);
 	template = template.replace(/\* @param([ ]\{\S+\})?\s+(\S+)[ \t]*$/gm, (_param, type, post) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/7](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/7)

To fully escape snippet meta-characters, both `$` and `\` must be escaped in the template. The best approach is to first escape all backslashes (`\` → `\\`), then dollars (`$` → `\$`), using a global regular expression. The order is important: if you escape `$` first then `\`, you might double-escape slashes that were inserted during the dollar escape.  
We should update line 106 to escape both with global replacement, and leave the rest of the logic unchanged. No new library is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
