### PR TITLE
Potential fix for code scanning alert no. 81: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,4 +1,6 @@
 name: Basic checks
+permissions:
+  contents: read
 
 on: workflow_dispatch
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/81](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/81)

To fix this problem, add a `permissions` block at the root of the workflow file (`.github/workflows/basic.yml`) to explicitly limit the permissions granted to the GITHUB_TOKEN for all jobs unless otherwise overridden. The minimal secure default suggested by CodeQL and GitHub documentation is `contents: read`, which is sufficient for most CI tasks that only need to read repository contents. Place the following block directly under the `name:` key and above the triggers (`on:`), so it applies globally to all jobs unless a more permissive job-level `permissions` block is later added. No new imports, methods, or definitions are required for this change—just a YAML modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
