### PR TITLE
Potential fix for code scanning alert no. 92: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/simple-browser/preview-src/index.ts
+++ b/extensions/simple-browser/preview-src/index.ts
@@ -99,11 +99,7 @@ onceDocumentLoaded(() => {
 				safeUrl = url.toString();
 			}
 		} catch {
-			// Fallback if URL parsing fails
-			// Try to match http/https only
-			if (/^(https?:\/\/)/i.test(rawUrl)) {
-				safeUrl = rawUrl;
-			}
+			// On parse error, do not attempt to match with regex; keep safeUrl as null.
 		}
 		if (safeUrl) {
 			iframe.src = safeUrl;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/92](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/92)

To safely assign URLs to the `iframe.src` property, always use the modern `URL` parser and validate the scheme (`http:` or `https:`) before proceeding. The fallback path (lines 104-106: regex match and direct assignment) is unsafe, since it relies on string prefix matching and passes untrusted input without proper validation. 

The best practice is:
- Remove the fallback path that uses regex/string matching and directly assigns `rawUrl` to `safeUrl`.
- Only assign to `iframe.src` after successfully parsing with the `URL` constructor and verifying the protocol is `http:` or `https:`.
- If parsing fails, always default to `about:blank` and do not load any untrusted URLs.

**Required changes**:
- In the `navigateTo` function (lines 92-115), remove the fallback block and only use the URL parser to construct and validate the URL.
- If an error occurs during parsing or the protocol is not valid, always assign 'about:blank' instead.

No new imports are required for this fix; just correct URL handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
