### PR TITLE
Potential fix for code scanning alert no. 39: Prototype-polluting function

### DIFF
--- a/src/vs/base/common/objects.ts
+++ b/src/vs/base/common/objects.ts
@@ -93,6 +93,10 @@ export function mixin(destination: any, source: any, overwrite: boolean = true):
 
 	if (isObject(source)) {
 		Object.keys(source).forEach(key => {
+			if (key === '__proto__' || key === 'constructor') {
+				// Prevent prototype pollution
+				return;
+			}
 			if (key in destination) {
 				if (overwrite) {
 					if (isObject(destination[key]) && isObject(source[key])) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/39](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/39)

To fix this issue, we need to prevent copying properties that can cause prototype pollution. This is best accomplished by blocking keys like `"__proto__"` and `"constructor"` in the loop that copies properties from `source` to `destination`. The safest fix is to add a check before any copy or recursion in the `Object.keys(source).forEach(key => { ... })` loop, skipping any key that is either `"__proto__"` or `"constructor"`. This check should precede any assignment or recursive merge.

Specifically, in `src/vs/base/common/objects.ts`, inside the `mixin` function, lines 95–107, add code to skip keys `"__proto__"` and `"constructor"` before performing assignments/recursive calls. No dependencies are needed; simple inline checks suffice. Do not modify other functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
