### PR TITLE
Potential fix for code scanning alert no. 46: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/media-preview/media/videoPreview.js
+++ b/extensions/media-preview/media/videoPreview.js
@@ -5,6 +5,18 @@
 // @ts-check
 "use strict";
 
+// Returns true if src is a safe URL for video.src
+function isSafeVideoSrc(src) {
+	try {
+		const allowedProtocols = ['http:', 'https:', 'blob:', 'filesystem:', ''];
+		// If relative URL, use document.baseURI as base
+		const url = new URL(src, document.baseURI);
+		return allowedProtocols.includes(url.protocol);
+	} catch {
+		return false;
+	}
+}
+
 (function () {
 	// @ts-ignore
 	const vscode = acquireVsCodeApi();
@@ -28,7 +40,7 @@
 
 	// Elements
 	const video = document.createElement('video');
-	if (settings.src !== null) {
+	if (settings.src !== null && isSafeVideoSrc(settings.src)) {
 		video.src = settings.src;
 	}
 	video.playsInline = true;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/46](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/46)

In general, the problem is that untrusted data (`settings.src`, derived from DOM attribute text and potentially attacker-controlled) is directly assigned to the `src` property of a video element. To fix this, we should validate or sanitize the value of `settings.src` before using it.

The best fix is to restrict the allowed protocols (e.g., only allow `http:`, `https:`, `blob:`, `filesystem:` or relative URLs) and reject any values with a potentially dangerous scheme like `javascript:`, `data:`, etc. Implement a function, e.g., `isSafeVideoSrc`, to check the URL scheme before assigning it to `video.src`. If `settings.src` is invalid, we should either not set `video.src` at all or set it to a safe fallback.

**Steps:**
- Implement a helper function such as `isSafeVideoSrc` that checks whether a given URL has an allowed scheme.
- Update the assignment to `video.src` on line 32 to only set the property if the value passes validation.
- If using URL parsing (e.g., `new URL()`), handle exceptions where the URL is invalid.
- Restrict the change just to this file and only touch the relevant code provided.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
