### PR TITLE
Potential fix for code scanning alert no. 85: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: workflow_dispatch
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/85](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/85)

To fix this, add an explicit `permissions` block to the workflow. Since the jobs do not appear to perform any action requiring write permissions (like publishing releases or writing to PRs), setting `permissions: contents: read` at the top/root of the workflow (right after the `name` field, before `on` and `jobs`) is sufficient and aligns with the principle of least privilege. This ensures the `GITHUB_TOKEN` will only have read access to repository contents unless specifically overridden in jobs. No further modifications are necessary unless a job is later updated to require additional privileges, in which case those jobs should have more permissive blocks added as required.

The required change is to insert a `permissions:` block at the proper location in `.github/workflows/ci.yml` (ideally after `name:` and before `on:`), setting `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
