### PR TITLE
Potential fix for code scanning alert no. 40: Prototype-polluting function

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1082,6 +1082,9 @@ function applyUpdate<T>(value: T | undefined, update: T): ApplyUpdateResult<T> {
 	let didChange = false;
 	for (const key in update) {
 		if ((update as T & object).hasOwnProperty(key)) {
+			if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+				continue;
+			}
 			const result = applyUpdate(value[key], update[key]);
 			if (result.didChange) {
 				value[key] = result.newValue;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/40](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/40)

The function should be guarded to prevent prototype pollution by blocking assignments for keys `"__proto__"`, `"constructor"`, and (optionally) `"prototype"` during the property update/merge process. To do this, edit the object key loop at line 1083 in `applyUpdate` to skip any iteration where the key matches one of these values.  
Specifically, between lines 1083 and 1085, add a check:  
```ts
if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
```  
No new imports are required.  
All edits are confined to the function `applyUpdate` (lines ~1074-1093).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
