### PR TITLE
Potential fix for code scanning alert no. 37: Shell command built from environment values

### DIFF
--- a/build/azure-pipelines/publish-types/update-types.ts
+++ b/build/azure-pipelines/publish-types/update-types.ts
@@ -16,7 +16,7 @@ try {
 
 	const dtsUri = `https://raw.githubusercontent.com/microsoft/vscode/${tag}/src/vscode-dts/vscode.d.ts`;
 	const outPath = path.resolve(process.cwd(), 'DefinitelyTyped/types/vscode/index.d.ts');
-	cp.execSync(`curl ${dtsUri} --output ${outPath}`);
+	cp.execFileSync('curl', [dtsUri, '--output', outPath]);
 
 	updateDTSFile(outPath, tag);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/37](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/37)

To address the problem, we need to avoid building the shell command by concatenating/interpolating unescaped values, instead passing them as arguments to the command directly. The safest/best fix is to use `child_process.execFileSync` instead of `execSync`, with the `curl` binary name as the command and the argument list as an array. This avoids any shell parsing of the arguments.  
Specifically:  
- On line 19, replace `cp.execSync(\`curl ${dtsUri} --output ${outPath}\`);` with `cp.execFileSync('curl', [dtsUri, '--output', outPath]);`
- No other code changes are needed.
- No new imports or definitions are required; `cp` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
