### PR TITLE
Potential fix for code scanning alert no. 47: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -311,7 +311,44 @@
 		document.body.classList.remove('loading');
 	});
 
-	image.src = settings.src;
+	/**
+	 * Validate and ensure only safe image sources can be used.
+	 * @param {string} src
+	 * @return {boolean}
+	 */
+	function isSafeImageSrc(src) {
+		try {
+			if (typeof src !== 'string' || src.length > 2048) {
+				return false;
+			}
+			// Allow http, https, file, and data URIs for images only
+			const allowedSchemes = ['http:', 'https:', 'file:'];
+			const urlMatch = src.match(/^([a-zA-Z0-9+.-]+):/);
+			if (!urlMatch) {
+				return false;
+			}
+			const scheme = urlMatch[1].toLowerCase() + ':';
+			if (allowedSchemes.includes(scheme)) {
+				return true;
+			}
+			if (scheme === 'data:') {
+				// Allow only image media types in data URLs
+				return /^data:image\/(png|jpe?g|gif|bmp|webp|svg\+xml);base64,/.test(src);
+			}
+			return false;
+		} catch {
+			return false;
+		}
+	}
+
+	if (isSafeImageSrc(settings.src)) {
+		image.src = settings.src;
+	} else {
+		console.error('Unsafe image src detected:', settings.src);
+		image.src = '';
+		document.body.classList.add('error');
+		document.body.classList.remove('loading');
+	}
 
 	document.querySelector('.open-file-link')?.addEventListener('click', (e) => {
 		e.preventDefault();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/47](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/47)

The best way to mitigate this potential vulnerability is to validate and restrict the value assigned to `image.src` so that only trusted and safe image sources are allowed. 

- Before assigning `settings.src` to `image.src` (line 314), check that it is a valid image URL. Allow only relevant schemes: e.g., `http:`, `https:`, `file:`, and optionally `data:` with content type restricted to images (`data:image/png`, `data:image/jpeg`, etc.).
- Disallow dangerous or unexpected URI schemes, such as `javascript:`, or any `data:` URI whose media type is not an image.
- Implement this validation as a helper function, e.g., `isSafeImageSrc`, and only assign the value to the `src` field if validation passes.
- If the value fails validation, set the `src` to a safe placeholder (e.g., empty string or a known safe default).

Edits required:
- Add a validation function for image source URLs.
- Replace direct assignment of `image.src = settings.src;` with a check using this function.
- No external dependencies are required; use standard JavaScript DOM and URL APIs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
