### PR TITLE
Potential fix for code scanning alert no. 71: Prototype-polluting function

### DIFF
--- a/src/vs/base/common/observableInternal/logging/debugger/utils.ts
+++ b/src/vs/base/common/observableInternal/logging/debugger/utils.ts
@@ -96,6 +96,9 @@ export class Throttler implements IDisposable {
 
 export function deepAssign<T>(target: T, source: T): void {
 	for (const key in source) {
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			continue;
+		}
 		if (!!target[key] && typeof target[key] === 'object' && !!source[key] && typeof source[key] === 'object') {
 			deepAssign(target[key], source[key]);
 		} else {
@@ -106,6 +109,9 @@ export function deepAssign<T>(target: T, source: T): void {
 
 export function deepAssignDeleteNulls<T>(target: T, source: T): void {
 	for (const key in source) {
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			continue;
+		}
 		if (source[key] === null) {
 			delete target[key];
 		} else if (!!target[key] && typeof target[key] === 'object' && !!source[key] && typeof source[key] === 'object') {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/71](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/71)

To fix the prototype pollution vulnerability in `deepAssign`, the code must guard against copying dangerous properties to the `target` object. The most robust, backwards-compatible approach is to explicitly skip copying properties named `"__proto__"`, `"constructor"`, and `"prototype"`, which are the keys used to access and manipulate object prototypes. This fix should be applied directly to the for-in property loop, both at the root and at recursive levels.

Edit the `deepAssign` function in `src/vs/base/common/observableInternal/logging/debugger/utils.ts`, inserting a check at the beginning of each iteration inside the `for` loop to continue (skip assigning) if the key matches these property names.  
No new external dependencies are needed.  
Optionally a helper like `isPollutionKey(key)` could be written for code cleanliness, but for minimal change, a simple inline check suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
