### PR TITLE
Potential fix for code scanning alert no. 72: Prototype-polluting function

### DIFF
--- a/src/vs/base/common/observableInternal/logging/debugger/utils.ts
+++ b/src/vs/base/common/observableInternal/logging/debugger/utils.ts
@@ -106,6 +106,9 @@ export function deepAssign<T>(target: T, source: T): void {
 
 export function deepAssignDeleteNulls<T>(target: T, source: T): void {
 	for (const key in source) {
+		if (key === '__proto__' || key === 'constructor') {
+			continue;
+		}
 		if (source[key] === null) {
 			delete target[key];
 		} else if (!!target[key] && typeof target[key] === 'object' && !!source[key] && typeof source[key] === 'object') {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/72](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/72)

To fix the problem, we need to block assignment or deletion of properties with names that could lead to prototype pollution—primarily `__proto__` and `constructor`. The best approach is to skip any keys in `source` that equal either `__proto__` or `constructor`. Optionally, we can also use `Object.hasOwnProperty.call(source, key)` to ensure only own (not inherited) properties are processed, but the main concern flagged by CodeQL is prototype-polluting property names. 

Specifically, in `deepAssignDeleteNulls` (lines 107-117), we should add a guard at the start of the loop:
- Skip any key matching `__proto__` or `constructor` (recommended by CodeQL).
- Optionally, skip keys that are not own properties of `source` (best practice, especially if `source` might inherit polluted prototype chains).

No extra library imports are needed; string comparison suffices for `'__proto__'` and `'constructor'`.

Edit the following lines:
- Line 108: After `for (const key in source) {`, add guard to `continue` if `key === '__proto__' || key === 'constructor'`.
- Optionally: add `if (!Object.prototype.hasOwnProperty.call(source, key)) continue;` after the line above.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
