### PR TITLE
Potential fix for code scanning alert no. 82: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   check-metdata:
     name: 'Check metadata'
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/82](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/82)

To fix the problem, we should add a `permissions` block to the workflow (either at the root level or at the job level) and grant only the minimal permissions required. Since the job only runs read-only operations—checking out code and installing/running packages—it appears that only `contents: read` is needed. This can be added either at the root (affecting all jobs) or directly inside the `check-metdata` job. In this case, since there is only one job, adding the block to the job is sufficient. Insert the following block above `runs-on` in the `check-metdata` job:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
