### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -1045,7 +1045,7 @@ const blockNormal = {
  */
 const gfmTable = edit('^ *([^\\n ].*)\\n' // Header
     + ' {0,3}((?:\\| *)?:?-+:? *(?:\\| *:?-+:? *)*(?:\\| *)?)' // Align
-    + '(?:\\n((?:(?! *\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)') // Cells
+    + '(?:\\n((?:(?! *\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)', 'i') // Cells: add case-insensitive flag
     .replace('hr', hr)
     .replace('heading', ' {0,3}#{1,6}(?:\\s|$)')
     .replace('blockquote', ' {0,3}>')
@@ -1058,7 +1058,7 @@ const gfmTable = edit('^ *([^\\n ].*)\\n' // Header
 const blockGfm = {
     ...blockNormal,
     table: gfmTable,
-    paragraph: edit(_paragraph)
+    paragraph: edit(_paragraph, 'i') // add case-insensitive flag
         .replace('hr', hr)
         .replace('heading', ' {0,3}#{1,6}(?:\\s|$)')
         .replace('|lheading', '') // setext headings don't interrupt commonmark paragraphs


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/2](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/2)

The best way to fix this problem is to make the regular expression for matching HTML tags case-insensitive so that tags like `<SCRIPT>` or `<ScRiPt>` are also correctly matched. In this code, the pattern for `script|pre|style|textarea|!--` should be matched in a case-insensitive manner.

To achieve that:
- Add the `i` (case-insensitive) flag to the corresponding regex.
- If the regex is constructed as a string for substitution, ensure the resulting regex is created with the `i` flag.
- Make sure all regexes in the grammar construction (`gfmTable`, and for `paragraph` in `blockGfm`, etc.) that use `html` are updated for case-insensitivity.

In this codebase (marked.js), there is an `edit()` helper to build regexes; it takes a flag argument, and we see an example above:
```js
1011: const paragraph = edit(_paragraph, 'i') // <-- add 'i' flag for case-insensitivity
```
However, for `gfmTable` and for `paragraph` in `blockGfm`, the regex does **not** have the `'i'` flag set on the calls to `edit()`. So, the fix is to add the `'i'` flag as the second argument to `.edit()` in both relevant places:
- `gfmTable`
- `blockGfm.paragraph`

This will ensure that all relevant HTML tag matches in the block grammar are case-insensitive.

**Regions to change:**  
- On the `gfmTable` definition (`edit(...)` at line 1046), add the `'i'` flag.
- On the `blockGfm.paragraph` definition (`edit(_paragraph)` at line 1061), add the `'i'` flag.

No library changes or imports are required; just change the `edit()` calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
