### PR TITLE
Potential fix for code scanning alert no. 93: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -333,7 +333,8 @@
 			}
 			if (scheme === 'data:') {
 				// Allow only image media types in data URLs
-				return /^data:image\/(png|jpe?g|gif|bmp|webp|svg\+xml);base64,/.test(src);
+				// Disallow SVG images for data URIs to mitigate XSS
+				return /^data:image\/(png|jpe?g|gif|bmp|webp);base64,/.test(src);
 			}
 			return false;
 		} catch {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/93](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/93)

To fix the problem, you should further restrict the use of SVG images in data URIs for the `img.src` attribute, because SVGs can contain JavaScript and other active content that can result in XSS vulnerabilities if not thoroughly sanitized. The single best change is to update the `isSafeImageSrc()` function to **disallow** SVG images in data URIs, or, if SVG images must be supported, ensure comprehensive sanitization before using them as an image source. In this context, the most effective fix is to **remove `svg+xml` from the list of allowed media types in data URIs**.

This change needs to be made in the file `extensions/media-preview/media/imagePreview.js`, specifically the regex on line 336 in the `isSafeImageSrc()` function. No new imports are needed, and you do not need to introduce any new variables or logic outside of updating this function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
