### PR TITLE
Potential fix for code scanning alert no. 5: Bad HTML filtering regexp

### DIFF
--- a/src/vs/editor/test/common/modes/supports/indentationRules.ts
+++ b/src/vs/editor/test/common/modes/supports/indentationRules.ts
@@ -27,7 +27,7 @@ export const goIndentationRules = {
 };
 
 export const htmlIndentationRules = {
-	decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/,
+	decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|--!?>|\})/,
 	increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/5](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/5)

To fix this, the comment end portion of the regex (`-->`) should be broadened to match both `-->` and `--!>`, since both are recognized by browsers as comment end tags. This can be done by replacing `-->` with `--!?` (the exclamation mark is optional) followed by `>`. The correct sequence for regex would be `--!?>(` to match `-->` and `--!>`, so the group becomes `(--!?>)`.

Only line 30 in `src/vs/editor/test/common/modes/supports/indentationRules.ts` needs to change:
```ts
30: 	decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/,
```
should become:
```ts
30: 	decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|--!?>|\})/,
```

No additional libraries, functions, or imports are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
