### PR TITLE
Potential fix for code scanning alert no. 4: Bad HTML filtering regexp

### DIFF
--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -1143,7 +1143,7 @@ const autolink = edit(/^<(scheme:[^\s\x00-\x1f<>]*|email)>/)
     .replace('scheme', /[a-zA-Z][a-zA-Z0-9+.-]{1,31}/)
     .replace('email', /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+(@)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(?![-_])/)
     .getRegex();
-const _inlineComment = edit(_comment).replace('(?:-->|$)', '-->').getRegex();
+const _inlineComment = edit(_comment).replace('(?:-->|$)', '(?:-->|--!>|$)').getRegex();
 const tag = edit('^comment'
     + '|^</[a-zA-Z][\\w:-]*\\s*>' // self-closing tag
     + '|^<[a-zA-Z][\\w-]*(?:attribute)*?\\s*/?>' // open tag


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/4](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/4)

To fix the problem, update the regular expression that recognizes the end of HTML comments so it matches both `-->` and `--!>`, as browsers support both because of their permissive parsing. The problematic regexp is set during the creation of `_inlineComment`, which is built on top of `_comment` but only replaces the end pattern for `-->`. Update the replacement so that it also matches `--!>`, replacing `(?:-->|$)` with `(?:-->|--!>|$)` in the `.replace` call on line 1146. This will ensure any comment ended with either `-->` or `--!>` is properly parsed. Only this single line needs to be updated in `src/vs/base/common/marked/marked.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
