### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
@@ -302,7 +302,7 @@ function escapeMarkdownLinkPath(mdPath: string): string {
 }
 
 function escapeBrackets(value: string): string {
-	value = value.replace(/[\[\]]/g, '\\$&'); // CodeQL [SM02383] The Markdown is fully sanitized after being rendered.
+	value = value.replace(/\\/g, '\\\\').replace(/[\[\]]/g, '\\$&'); // CodeQL [SM02383] The Markdown is fully sanitized after being rendered.
 	return value;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/6](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/6)

To fix this problem, edit the `escapeBrackets` function to also escape backslashes (`\`). This must be done *before* escaping square brackets, since otherwise newly added backslashes (from bracket escaping) themselves may need escaping. Use a regular expression with the global flag to replace each occurrence of a backslash (`\`) with double backslash (`\\`), followed by the square bracket escaping as currently done. This fix should only require editing the code on line 305, inside the `escapeBrackets` function in `extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts`. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
