### PR TITLE
Potential fix for code scanning alert no. 91: Client-side cross-site scripting

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2466,15 +2466,43 @@ async function webviewPreloads(ctx: PreloadContext) {
 	function sanitizeHTML(dirty) {
 		const template = document.createElement('template');
 		template.innerHTML = dirty;
-		// Remove all <script> elements
-		for (const script of template.content.querySelectorAll('script')) {
-			script.remove();
-		}
-		// Remove event handler attributes (on*)
+
+		// Remove potentially dangerous elements
+		const forbiddenTags = [
+			'script', 'style', 'iframe', 'object', 'embed', 'link', 'base', 'meta', 'form', 'input', 'button'
+		];
+		forbiddenTags.forEach(tag => {
+			for (const el of Array.from(template.content.querySelectorAll(tag))) {
+				el.remove();
+			}
+		});
+
+		// Remove event handler attributes (on*), style, srcdoc, javascript: URLs
 		for (const el of template.content.querySelectorAll('*')) {
 			for (const attr of Array.from(el.attributes)) {
-				if (/^on/i.test(attr.name)) {
-					el.removeAttribute(attr.name);
+				const name = attr.name;
+				const value = attr.value;
+
+				// Remove inline event handlers
+				if (/^on/i.test(name)) {
+					el.removeAttribute(name);
+					continue;
+				}
+				// Remove style attributes (CSS attacks)
+				if (/^style$/i.test(name)) {
+					el.removeAttribute(name);
+					continue;
+				}
+				// Remove srcdoc attribute
+				if (/^srcdoc$/i.test(name)) {
+					el.removeAttribute(name);
+					continue;
+				}
+				// Remove javascript: URIs in src/href/data attrs
+				if (/^(src|href|data)$/i.test(name) &&
+					/^javascript:/i.test(value.trim())) {
+					el.removeAttribute(name);
+					continue;
 				}
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/91](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/91)

To fix this vulnerability, we need to ensure any user-provided HTML is robustly sanitized before it reaches a DOM sink such as `innerHTML`. The best practice is to use a well-reviewed library such as [DOMPurify](https://github.com/cure53/DOMPurify) rather than relying on home-brewed sanitizers, which are likely to miss edge cases and attack vectors.

However, per the comments in this file, direct imports are not allowed since this code is intended to be stringified and injected into a webview. Therefore, the only option is to improve the in-file sanitizer as much as possible. This involves:
- Removing not just `<script>`, but also `<style>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, and potentially more tags.
- Removing dangerous attributes such as `srcdoc`, `data`, `src`, and `href` with javascript: URIs.
- Stripping `style` attributes that could contain CSS-based attacks.
- Optionally, a whitelist-based approach: only allow a small subset of tags and attributes.

Given the constraints, we should:
- Expand the sanitizer to remove more dangerous tags (using a blocklist).
- Remove attributes with dangerous values (e.g., `javascript:` in `href`, `src`, etc.).
- Remove `style` attributes.
- Continue to remove all `on*` event handlers.
- Comment the code with a strong warning that a full-featured sanitizer should be used if/when allowed.

**What needs to change:**
- Update the function `sanitizeHTML` in lines 2466–2482 to expand its filtering as described above.
- Ensure only that block is changed; the function signature and its usage are retained.
- Possibly, improve detection of dangerous attributes and markup. Filter additional tags/attributes at this step.


---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
