### PR TITLE
Potential fix for code scanning alert no. 109: Client-side cross-site scripting

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2464,6 +2464,13 @@ async function webviewPreloads(ctx: PreloadContext) {
 	// --- Begin DOMPurify Minimal Implementation ---
 	// NOTE: In a production scenario, the full DOMPurify min.js should be included here or loaded up-front wherever allowed. This is a minimal, very basic, example for the notebook webview context.
 	function sanitizeHTML(dirty) {
+		// Ensure we only ever process strings to avoid unexpected DOM parsing behavior
+		if (dirty === undefined || dirty === null) {
+			dirty = '';
+		} else if (typeof dirty !== 'string') {
+			dirty = String(dirty);
+		}
+
 		const template = document.createElement('template');
 		template.innerHTML = dirty;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/109](https://github.com/Git-Hub-Chris/MicrosoftVsCode/security/code-scanning/109)

In general, to fix DOM XSS when writing user-controlled HTML into the DOM, you must ensure that only safe, expected markup is allowed and that everything else is stripped or rejected. This usually means either (1) not using `innerHTML` at all and instead inserting only text nodes, or (2) passing the HTML through a robust sanitizer that strictly validates types and disallows all dangerous elements, attributes, and URL schemes, combined with Trusted Types where available.

In this specific code, the vulnerable point is `template.innerHTML = dirty;` inside the `sanitizeHTML(dirty)` function at lines 2466–2510. The data (`dirty`) is tainted via `event.data.html` from `postMessage`. We already have a sanitizer that removes dangerous tags and attributes after setting `innerHTML`, and the caller wraps the result in a Trusted Types policy (`ttPolicy?.createHTML(safeHtml) ?? safeHtml`) before assigning it to `el.innerHTML`. To tighten this without changing behavior, we should: (1) ensure `sanitizeHTML` only operates on strings so that non-string or unexpected types cannot cause odd DOM parsing behavior; and (2) keep the existing removal logic, which is already fairly strict. We can implement this by adding a type check/coercion at the start of `sanitizeHTML(dirty)` that ensures `dirty` is a primitive string and falls back to a safe empty string otherwise. This change is confined to the shown function and does not require new imports or structural changes.

Concretely: in `src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts`, within the lower `sanitizeHTML(dirty)` implementation (around line 2466), add a guard so that if `dirty` is not a string, we either convert it via `String(dirty)` or return an empty string. For maximum safety and minimal behavior change, we can convert only primitive strings and other primitives via `String`, but if `dirty` is `null`/`undefined` we should treat it as empty. After this, the rest of the sanitizer remains as is. No other files or methods need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
